### PR TITLE
Fix `balance_works()` test across ERC20 code examples

### DIFF
--- a/2/assets/2.2-finished-code.rs
+++ b/2/assets/2.2-finished-code.rs
@@ -70,7 +70,8 @@ mod erc20 {
         fn balance_works() {
             let contract = Erc20::new(100);
             assert_eq!(contract.total_supply(), 100);
-            assert_eq!(contract.balance_of(AccountId::from([0x1; 32])), 0);
+            assert_eq!(contract.balance_of(AccountId::from([0x1; 32])), 100);
+            assert_eq!(contract.balance_of(AccountId::from([0x0; 32])), 0);
         }
 
         #[test]

--- a/2/assets/2.2-template.rs
+++ b/2/assets/2.2-template.rs
@@ -67,7 +67,8 @@ mod erc20 {
         fn balance_works() {
             let contract = Erc20::new(100);
             assert_eq!(contract.total_supply(), 100);
-            assert_eq!(contract.balance_of(AccountId::from([0x1; 32])), 0);
+            assert_eq!(contract.balance_of(AccountId::from([0x1; 32])), 100);
+            assert_eq!(contract.balance_of(AccountId::from([0x0; 32])), 0);
         }
 
         #[test]

--- a/2/assets/2.3-finished-code.rs
+++ b/2/assets/2.3-finished-code.rs
@@ -90,7 +90,8 @@ mod erc20 {
         fn balance_works() {
             let contract = Erc20::new(100);
             assert_eq!(contract.total_supply(), 100);
-            assert_eq!(contract.balance_of(AccountId::from([0x1; 32])), 0);
+            assert_eq!(contract.balance_of(AccountId::from([0x1; 32])), 100);
+            assert_eq!(contract.balance_of(AccountId::from([0x0; 32])), 0);
         }
 
         #[test]

--- a/2/assets/2.3-template.rs
+++ b/2/assets/2.3-template.rs
@@ -82,7 +82,8 @@ mod erc20 {
         fn balance_works() {
             let contract = Erc20::new(100);
             assert_eq!(contract.total_supply(), 100);
-            assert_eq!(contract.balance_of(AccountId::from([0x1; 32])), 0);
+            assert_eq!(contract.balance_of(AccountId::from([0x1; 32])), 100);
+            assert_eq!(contract.balance_of(AccountId::from([0x0; 32])), 0);
         }
 
         #[test]

--- a/2/assets/2.4-finished-code.rs
+++ b/2/assets/2.4-finished-code.rs
@@ -133,7 +133,8 @@ mod erc20 {
         fn balance_works() {
             let contract = Erc20::new(100);
             assert_eq!(contract.total_supply(), 100);
-            assert_eq!(contract.balance_of(AccountId::from([0x1; 32])), 0);
+            assert_eq!(contract.balance_of(AccountId::from([0x1; 32])), 100);
+            assert_eq!(contract.balance_of(AccountId::from([0x0; 32])), 0);
         }
 
         #[test]

--- a/2/assets/2.4-template.rs
+++ b/2/assets/2.4-template.rs
@@ -127,7 +127,8 @@ mod erc20 {
         fn balance_works() {
             let contract = Erc20::new(100);
             assert_eq!(contract.total_supply(), 100);
-            assert_eq!(contract.balance_of(AccountId::from([0x1; 32])), 0);
+            assert_eq!(contract.balance_of(AccountId::from([0x1; 32])), 100);
+            assert_eq!(contract.balance_of(AccountId::from([0x0; 32])), 0);
         }
 
         #[test]


### PR DESCRIPTION
`balance_works()` tests in 2.2-2.4 differed from corresponding test in 2.1 and failed since initial balance of contract instantiator should match total supply.