### PR TITLE
Update my_getter to be public

### DIFF
--- a/1/getting-a-value.md
+++ b/1/getting-a-value.md
@@ -73,7 +73,7 @@ We already showed you how to initialize a storage value. Getting the value is ju
 ```rust
 impl MyContract {
     #[ink(message)]
-    fn my_getter(&self) -> u32 {
+    pub fn my_getter(&self) -> u32 {
         self.number
     }
 }


### PR DESCRIPTION
Given that it's a getter and has the #[ink(message)] annotation it should be publicly exposed.