### PR TITLE
Add default constructor

### DIFF
--- a/1/storing-a-mapping.md
+++ b/1/storing-a-mapping.md
@@ -82,6 +82,15 @@ mod mycontract {
     }
 
     impl MyContract {
+        /// Public function.
+        /// Default constructor.
+        #[ink(constructor)]
+        pub fn default() -> Self {
+            Self {
+                my_number_map: Default::default(),
+            }
+        }
+    
         /// Private function.
         /// Returns the number for an AccountId or 0 if it is not set.
         fn my_number_or_zero(&self, of: &AccountId) -> u32 {


### PR DESCRIPTION
Adds the default constructor to the HashMap initialization section. Not sure if this is a distraction from the main points but it's something I stumbled upon while working on the quiz.