### PR TITLE
Switch from u64 to i32

### DIFF
--- a/1/assets/1.5-finished-code.rs
+++ b/1/assets/1.5-finished-code.rs
@@ -9,7 +9,7 @@ mod incrementer {
     #[ink(storage)]
     pub struct Incrementer {
         value: i32,
-        my_value: ink_storage::collections::HashMap<AccountId, u64>,
+        my_value: ink_storage::collections::HashMap<AccountId, i32>,
     }
 
     impl Incrementer {
@@ -40,11 +40,11 @@ mod incrementer {
         }
 
         #[ink(message)]
-        pub fn get_mine(&self) -> u64 {
+        pub fn get_mine(&self) -> i32 {
             self.my_value_or_zero(&self.env().caller())
         }
 
-        fn my_value_or_zero(&self, of: &AccountId) -> u64 {
+        fn my_value_or_zero(&self, of: &AccountId) -> i32 {
             *self.my_value.get(of).unwrap_or(&0)
         }
     }

--- a/1/assets/1.5-template.rs
+++ b/1/assets/1.5-template.rs
@@ -9,7 +9,7 @@ mod incrementer {
     #[ink(storage)]
     pub struct Incrementer {
         value: i32,
-        // ACTION: Add a `HashMap` from `AccountId` to `u64` named `my_value`
+        // ACTION: Add a `HashMap` from `AccountId` to `i32` named `my_value`
     }
 
     impl Incrementer {
@@ -38,12 +38,12 @@ mod incrementer {
         }
 
         #[ink(message)]
-        pub fn get_mine(&self) -> u64 {
+        pub fn get_mine(&self) -> i32 {
             // ACTION: Get `my_value` using `my_value_or_zero` on `&self.env().caller()`
             // ACTION: Return `my_value`
         }
 
-        fn my_value_or_zero(&self, of: &AccountId) -> u64 {
+        fn my_value_or_zero(&self, of: &AccountId) -> i32 {
             // ACTION: `get` and return the value of `of` and `unwrap_or` return 0
         }
     }

--- a/1/assets/1.6-finished-code.rs
+++ b/1/assets/1.6-finished-code.rs
@@ -8,7 +8,7 @@ mod incrementer {
     #[ink(storage)]
     pub struct Incrementer {
         value: i32,
-        my_value: ink_storage::collections::HashMap<AccountId, u64>,
+        my_value: ink_storage::collections::HashMap<AccountId, i32>,
     }
 
     impl Incrementer {
@@ -39,18 +39,18 @@ mod incrementer {
         }
 
         #[ink(message)]
-        pub fn get_mine(&self) -> u64 {
+        pub fn get_mine(&self) -> i32 {
             self.my_value_or_zero(&self.env().caller())
         }
 
         #[ink(message)]
-        pub fn inc_mine(&mut self, by: u64) {
+        pub fn inc_mine(&mut self, by: i32) {
             let caller = self.env().caller();
             let my_value = self.my_value_or_zero(&caller);
             self.my_value.insert(caller, my_value + by);
         }
 
-        fn my_value_or_zero(&self, of: &AccountId) -> u64 {
+        fn my_value_or_zero(&self, of: &AccountId) -> i32 {
             *self.my_value.get(of).unwrap_or(&0)
         }
     }

--- a/1/assets/1.6-template.rs
+++ b/1/assets/1.6-template.rs
@@ -8,7 +8,7 @@ mod incrementer {
     #[ink(storage)]
     pub struct Incrementer {
         value: i32,
-        my_value: ink_storage::collections::HashMap<AccountId, u64>,
+        my_value: ink_storage::collections::HashMap<AccountId, i32>,
     }
 
     impl Incrementer {
@@ -39,18 +39,18 @@ mod incrementer {
         }
 
         #[ink(message)]
-        pub fn get_mine(&self) -> u64 {
+        pub fn get_mine(&self) -> i32 {
             self.my_value_or_zero(&self.env().caller())
         }
 
         #[ink(message)]
-        pub fn inc_mine(&mut self, by: u64) {
+        pub fn inc_mine(&mut self, by: i32) {
             // ACTION: Get the `caller` of this function.
             // ACTION: Get `my_value` that belongs to `caller` by using `my_value_or_zero`.
             // ACTION: Insert the incremented `value` back into the mapping.
         }
 
-        fn my_value_or_zero(&self, of: &AccountId) -> u64 {
+        fn my_value_or_zero(&self, of: &AccountId) -> i32 {
             *self.my_value.get(of).unwrap_or(&0)
         }
     }


### PR DESCRIPTION
This ensures that the overall codebase is more consistent as discussed in #83.

Closes #83