### PR TITLE
Revert "Update to new cargo-contract cli commands (#86)"

### DIFF
--- a/0/building-your-contract.md
+++ b/0/building-your-contract.md
@@ -7,16 +7,30 @@ Run the following command to compile your smart contract:
 cargo +nightly contract build
 ```
 
-This special command will turn your ink! project into a Wasm binary and a metadata file (a.k.a.  the contract ABI).
-These two files can be used for deploying your contract to your chain. If all goes well, you should see a `target` folder which contains this `.wasm` and `metadata.json` file.
+This special command will turn your ink! project into a Wasm binary which you can deploy to your chain. If all goes well, you should see a `target` folder which contains this `.wasm` file.
 
 ```
 target
 └── flipper.wasm
+```
+
+## Contract Metadata
+
+By running the next command we'll generate the contract metadata (a.k.a. the contract ABI):
+
+``` bash
+cargo +nightly contract generate-metadata
+```
+
+You should have a new JSON file (`metadata.json`) in the same target directory:
+
+``` bash
+target
+├── flipper.wasm
 └── metadata.json
 ```
 
-Let's take a look at the structure of the `meatadata.json`:
+Let's take a look at the structure inside:
 
 ``` JSON
 {


### PR DESCRIPTION
This reverts commit 7786be2f447dd0e0b499ea54f0cee030a118b067.

I was too fast with the PR, the new `cargo contract` cli is not yet published to crates.io.