### PR TITLE
minor - removed unused constructor argument

### DIFF
--- a/1/incrementing-the-value.md
+++ b/1/incrementing-the-value.md
@@ -36,7 +36,7 @@ pub struct MyContract {
 
 impl MyContract {
     #[ink(constructor)]
-    pub fn new(init_value: i32) -> Self {
+    pub fn new() -> Self {
         Self {
             my_number: Default::default(),
         }

--- a/1/storing-a-mapping.md
+++ b/1/storing-a-mapping.md
@@ -168,7 +168,7 @@ mod mycontract {
 
     impl MyContract {
         #[ink(constructor)]
-        pub fn new(init_value: i32) -> Self {
+        pub fn new() -> Self {
             Self {
                 owner: Self::env().caller();
             }


### PR DESCRIPTION
Hi guys, substrate-contracts-workshop is really awesome! Well done :)

I just spotted one unused argument, feel free to merge it. 
Or advice me what PR process I should follow.

Edited:
hmm or maybe it's better to keep it and refactor it slightly
```
pub fn new(init_value: u32) -> Self {
    Self {
        my_number: ink_storage::Lazy::<u32>::new(init_value),
    }
}
```