### PR TITLE
erc20 minor improvements + allowances bugfix

### DIFF
--- a/1/incrementing-the-value.md
+++ b/1/incrementing-the-value.md
@@ -36,7 +36,7 @@ pub struct MyContract {
 
 impl MyContract {
     #[ink(constructor)]
-    pub fn new(init_value: i32) -> Self {
+    pub fn new() -> Self {
         Self {
             my_number: Default::default(),
         }

--- a/2/assets/2.1-template.rs
+++ b/2/assets/2.1-template.rs
@@ -16,8 +16,8 @@ mod erc20 {
     impl Erc20 {
         #[ink(constructor)]
         pub fn new(initial_supply: Balance) -> Self {
-            // ACTION: `set` the total supply to `init_value`
-            // ACTION: `insert` the `init_value` as the `caller` balance
+            // ACTION: `set` the total supply to `initial_supply`
+            // ACTION: `insert` the `initial_supply` as the `caller` balance
         }
 
         #[ink(message)]

--- a/2/assets/2.3-template.rs
+++ b/2/assets/2.3-template.rs
@@ -27,7 +27,7 @@ mod erc20 {
             let mut balances = ink_storage::collections::HashMap::new();
             balances.insert(Self::env().caller(), initial_supply);
 
-            // ACTION: Call `self.env().emit_event` with the `Transfer` event
+            // ACTION: Call `Self::env().emit_event` with the `Transfer` event
             //   HINT: Since we use `Option<AccountId>`, you need to wrap accounts in `Some()`
 
             Self {

--- a/2/assets/2.4-finished-code.rs
+++ b/2/assets/2.4-finished-code.rs
@@ -94,9 +94,14 @@ mod erc20 {
                 return false;
             }
 
+            let transfer_result = self.transfer_from_to(from, to, value);
+            if !transfer_result {
+                return false
+            }
+
             // Decrease the value of the allowance and transfer the tokens.
             self.allowances.insert((from, caller), allowance - value);
-            self.transfer_from_to(from, to, value)
+            true
         }
 
         #[ink(message)]
@@ -171,6 +176,22 @@ mod erc20 {
             contract.approve(AccountId::from([0x1; 32]), 20);
             contract.transfer_from(AccountId::from([0x1; 32]), AccountId::from([0x0; 32]), 10);
             assert_eq!(contract.balance_of(AccountId::from([0x0; 32])), 10);
+        }
+
+        #[ink::test]
+        fn allowances_works() {
+            let mut contract = Erc20::new(100);
+            assert_eq!(contract.balance_of(AccountId::from([0x1; 32])), 100);
+            contract.approve(AccountId::from([0x1; 32]), 200);
+            assert_eq!(contract.allowance(AccountId::from([0x1; 32]), AccountId::from([0x1; 32])), 200);
+
+            assert!(contract.transfer_from(AccountId::from([0x1; 32]), AccountId::from([0x0; 32]), 50));
+            assert_eq!(contract.balance_of(AccountId::from([0x0; 32])), 50);
+            assert_eq!(contract.allowance(AccountId::from([0x1; 32]), AccountId::from([0x1; 32])), 150);
+
+            assert!(!contract.transfer_from(AccountId::from([0x1; 32]), AccountId::from([0x0; 32]), 100));
+            assert_eq!(contract.balance_of(AccountId::from([0x0; 32])), 50);
+            assert_eq!(contract.allowance(AccountId::from([0x1; 32]), AccountId::from([0x1; 32])), 150);
         }
     }
 }


### PR DESCRIPTION
Hey all,
I've just spotted a few minor typos and one bug.

My understanding of allowances is that user can approve() more than his existing balance.
If that's a correct assumption, this test ```allowances_works()```would fail.

Steps to reproduce:
1. User has balance equal to 100
2. User approve 200
3. User try to```transfer_from()``` 150.
4. ```transfer_from()``` would fail but allowances are being decreased anyway


Let me know what you think ^^