### PR TITLE
Use `#[ink::test]` instead of `#[test]`

### DIFF
--- a/1/assets/1.1-finished-code.rs
+++ b/1/assets/1.1-finished-code.rs
@@ -25,7 +25,7 @@ mod incrementer {
 
     #[cfg(test)]
     mod tests {
-        #[test]
+        #[ink::test]
         fn default_works() {
             // Test Your Contract
         }

--- a/1/assets/1.1-finished-code.rs
+++ b/1/assets/1.1-finished-code.rs
@@ -25,6 +25,9 @@ mod incrementer {
 
     #[cfg(test)]
     mod tests {
+        use super::*;
+        use ink_lang as ink;
+
         #[ink::test]
         fn default_works() {
             // Test Your Contract

--- a/1/assets/1.2-finished-code.rs
+++ b/1/assets/1.2-finished-code.rs
@@ -34,6 +34,7 @@ mod incrementer {
     #[cfg(test)]
     mod tests {
         use super::*;
+        use ink_lang as ink;
 
         #[ink::test]
         fn default_works() {

--- a/1/assets/1.2-finished-code.rs
+++ b/1/assets/1.2-finished-code.rs
@@ -35,7 +35,7 @@ mod incrementer {
     mod tests {
         use super::*;
 
-        #[test]
+        #[ink::test]
         fn default_works() {
             Incrementer::default();
         }

--- a/1/assets/1.2-template.rs
+++ b/1/assets/1.2-template.rs
@@ -31,7 +31,7 @@ mod incrementer {
     mod tests {
         use super::*;
 
-        #[test]
+        #[ink::test]
         fn default_works() {
             Incrementer::default();
         }

--- a/1/assets/1.2-template.rs
+++ b/1/assets/1.2-template.rs
@@ -30,6 +30,7 @@ mod incrementer {
     #[cfg(test)]
     mod tests {
         use super::*;
+        use ink_lang as ink;
 
         #[ink::test]
         fn default_works() {

--- a/1/assets/1.3-finished-code.rs
+++ b/1/assets/1.3-finished-code.rs
@@ -36,7 +36,7 @@ mod incrementer {
     mod tests {
         use super::*;
 
-        #[test]
+        #[ink::test]
         fn default_works() {
             let contract = Incrementer::default();
             assert_eq!(contract.get(), 0);

--- a/1/assets/1.3-finished-code.rs
+++ b/1/assets/1.3-finished-code.rs
@@ -35,6 +35,7 @@ mod incrementer {
     #[cfg(test)]
     mod tests {
         use super::*;
+        use ink_lang as ink;
 
         #[ink::test]
         fn default_works() {

--- a/1/assets/1.3-template.rs
+++ b/1/assets/1.3-template.rs
@@ -37,7 +37,7 @@ mod incrementer {
     mod tests {
         use super::*;
 
-        #[test]
+        #[ink::test]
         fn default_works() {
             let contract = Incrementer::default();
             assert_eq!(contract.get(), 0);

--- a/1/assets/1.3-template.rs
+++ b/1/assets/1.3-template.rs
@@ -36,6 +36,7 @@ mod incrementer {
     #[cfg(test)]
     mod tests {
         use super::*;
+        use ink_lang as ink;
 
         #[ink::test]
         fn default_works() {

--- a/1/assets/1.4-finished-code.rs
+++ b/1/assets/1.4-finished-code.rs
@@ -40,6 +40,7 @@ mod incrementer {
     #[cfg(test)]
     mod tests {
         use super::*;
+        use ink_lang as ink;
 
         #[ink::test]
         fn default_works() {

--- a/1/assets/1.4-finished-code.rs
+++ b/1/assets/1.4-finished-code.rs
@@ -41,13 +41,13 @@ mod incrementer {
     mod tests {
         use super::*;
 
-        #[test]
+        #[ink::test]
         fn default_works() {
             let contract = Incrementer::default();
             assert_eq!(contract.get(), 0);
         }
 
-        #[test]
+        #[ink::test]
         fn it_works() {
             let mut contract = Incrementer::new(42);
             assert_eq!(contract.get(), 42);

--- a/1/assets/1.4-template.rs
+++ b/1/assets/1.4-template.rs
@@ -40,6 +40,7 @@ mod incrementer {
     #[cfg(test)]
     mod tests {
         use super::*;
+        use ink_lang as ink;
 
         #[ink::test]
         fn default_works() {

--- a/1/assets/1.4-template.rs
+++ b/1/assets/1.4-template.rs
@@ -41,13 +41,13 @@ mod incrementer {
     mod tests {
         use super::*;
 
-        #[test]
+        #[ink::test]
         fn default_works() {
             let contract = Incrementer::default();
             assert_eq!(contract.get(), 0);
         }
 
-        #[test]
+        #[ink::test]
         fn it_works() {
             let mut contract = Incrementer::new(42);
             assert_eq!(contract.get(), 42);

--- a/1/assets/1.5-finished-code.rs
+++ b/1/assets/1.5-finished-code.rs
@@ -55,13 +55,13 @@ mod incrementer {
 
         use ink_lang as ink;
 
-        #[test]
+        #[ink::test]
         fn default_works() {
             let contract = Incrementer::default();
             assert_eq!(contract.get(), 0);
         }
 
-        #[test]
+        #[ink::test]
         fn it_works() {
             let mut contract = Incrementer::new(42);
             assert_eq!(contract.get(), 42);

--- a/1/assets/1.5-template.rs
+++ b/1/assets/1.5-template.rs
@@ -55,13 +55,13 @@ mod incrementer {
         // Alias `ink_lang` so we can use `ink::test`.
         use ink_lang as ink;
 
-        #[test]
+        #[ink::test]
         fn default_works() {
             let contract = Incrementer::default();
             assert_eq!(contract.get(), 0);
         }
 
-        #[test]
+        #[ink::test]
         fn it_works() {
             let mut contract = Incrementer::new(42);
             assert_eq!(contract.get(), 42);

--- a/1/assets/1.6-finished-code.rs
+++ b/1/assets/1.6-finished-code.rs
@@ -61,13 +61,13 @@ mod incrementer {
 
         use ink_lang as ink;
 
-        #[test]
+        #[ink::test]
         fn default_works() {
             let contract = Incrementer::default();
             assert_eq!(contract.get(), 0);
         }
 
-        #[test]
+        #[ink::test]
         fn it_works() {
             let mut contract = Incrementer::new(42);
             assert_eq!(contract.get(), 42);

--- a/1/assets/1.6-template.rs
+++ b/1/assets/1.6-template.rs
@@ -61,13 +61,13 @@ mod incrementer {
 
         use ink_lang as ink;
 
-        #[test]
+        #[ink::test]
         fn default_works() {
             let contract = Incrementer::default();
             assert_eq!(contract.get(), 0);
         }
 
-        #[test]
+        #[ink::test]
         fn it_works() {
             let mut contract = Incrementer::new(42);
             assert_eq!(contract.get(), 42);


### PR DESCRIPTION
Needed for https://github.com/paritytech/ink/issues/714.