### PR TITLE
proposal to add missing `ACTION:` hints

### DIFF
--- a/1/assets/1.5-template.rs
+++ b/1/assets/1.5-template.rs
@@ -17,6 +17,7 @@ mod incrementer {
         pub fn new(init_value: i32) -> Self {
             Self {
                 value: init_value,
+				// ACTION: Set initial `my_value`
             }
         }
 
@@ -24,6 +25,7 @@ mod incrementer {
         pub fn default() -> Self {
             Self {
                 value: 0,
+				// ACTION: Set default `my_value`
             }
         }
 

--- a/2/assets/2.4-template.rs
+++ b/2/assets/2.4-template.rs
@@ -44,10 +44,12 @@ mod erc20 {
 				to: Some(caller),
 				value: initial_supply,
 			});
-
+			
+			// ACTION: add allowances initialization
 			Self {
 				total_supply: initial_supply,
-				balances
+				balances,
+				
 			}
 		}
 


### PR DESCRIPTION
Missed hints for values initialization in constructor (for newly added fields to struct)